### PR TITLE
and/or/xor variable parameter fix

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogical.java
+++ b/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogical.java
@@ -38,7 +38,7 @@ abstract class BooleanExpressionFunctionLogical<C extends ExpressionFunctionCont
     }
 
     final static ExpressionFunctionParameter<Boolean> PARAMETER = ExpressionFunctionParameterName.with("parameter")
-            .required(Boolean.class);
+            .variable(Boolean.class);
 
     private final static List<ExpressionFunctionParameter<?>> PARAMETERS = ExpressionFunctionParameter.list(
             PARAMETER

--- a/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalAnd.java
+++ b/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalAnd.java
@@ -51,13 +51,11 @@ final class BooleanExpressionFunctionLogicalAnd<C extends ExpressionFunctionCont
 
         boolean result = true;
 
-        int i = 0;
-        while (i < count) {
-            result = result & PARAMETER.getOrFail(parameters, i);
+        for (final Boolean value : PARAMETER.getVariable(parameters, 0)) {
+            result = result && value;
             if (!result) {
                 break;
             }
-            i++;
         }
 
         return result;

--- a/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalOr.java
+++ b/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalOr.java
@@ -51,13 +51,11 @@ final class BooleanExpressionFunctionLogicalOr<C extends ExpressionFunctionConte
 
         boolean result = false;
 
-        int i = 0;
-        while (i < count) {
-            result = result | PARAMETER.getOrFail(parameters, i);
+        for (final Boolean value : PARAMETER.getVariable(parameters, 0)) {
+            result = result || value;
             if (result) {
                 break;
             }
-            i++;
         }
 
         return result;

--- a/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalXor.java
+++ b/src/main/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalXor.java
@@ -51,10 +51,8 @@ final class BooleanExpressionFunctionLogicalXor<C extends ExpressionFunctionCont
 
         boolean result = false;
 
-        int i = 0;
-        while (i < count) {
-            result = result ^ PARAMETER.getOrFail(parameters, i);
-            i++;
+        for (final Boolean value : PARAMETER.getVariable(parameters, 0)) {
+            result = result ^ value;
         }
 
         return result;

--- a/src/test/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalAndTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/booleann/BooleanExpressionFunctionLogicalAndTest.java
@@ -49,7 +49,7 @@ public final class BooleanExpressionFunctionLogicalAndTest extends BooleanExpres
     }
 
     @Test
-    public void testTrueFalse() {
+    public void testTrueFalseNonBoolean() {
         this.applyAndCheck2(
                 Lists.of(true, false, 99), // 99 never getted or cast so ignored
                 false


### PR DESCRIPTION
- Previously the parameter was REQUIRED which caused AIOBE when executed by SpreadsheetServerExpressionFunctionsTest.